### PR TITLE
Avoid using non-forking subshells with `-c` option

### DIFF
--- a/src/cmd/ksh93/sh/main.c
+++ b/src/cmd/ksh93/sh/main.c
@@ -580,13 +580,6 @@ static void	exfile(register Shell_t *shp, register Sfio_t *iop,register int fno)
 		if(t)
 		{
 			execflags = sh_state(SH_ERREXIT)|sh_state(SH_INTERACTIVE);
-			/* The last command may not have to fork */
-			if(!sh_isstate(SH_PROFILE) && sh_isoption(SH_CFLAG) &&
-				(fno<0 || !(shp->fdstatus[fno]&(IOTTY|IONOSEEK)))
-				&& !sfreserve(iop,0,0))
-			{
-					execflags |= sh_state(SH_NOFORK);
-			}
 			shp->st.execbrk = 0;
 			sh_exec(t,execflags);
 			if(shp->forked)

--- a/src/cmd/ksh93/tests/io.sh
+++ b/src/cmd/ksh93/tests/io.sh
@@ -496,4 +496,17 @@ done	{n}< /dev/null
 n=$( exec {n}< /dev/null; print -r -- $n)
 [[ -r /dev/fd/$n ]] && err_exit "file descriptor n=$n left open after subshell"
 
+# ==========
+# https://github.com/att/ast/issues/9
+tf=`mktemp`
+echo foo bar > $tf
+$SHELL -c 'echo xxx 1<>; '$tf
+actual=$(cat $tf)
+expect="xxx"
+[[ "$actual" = "$expect" ]] || err_exit "<>; does not truncate files - $expect - $actual"
+rm -f $tf
+
+$SHELL -c '{ echo "Foo"; echo "bar"; uname; } >; '$tf
+[[ -s "$tf" ]] || err_exit ">; does not work with -c"
+rm -f $tf
 exit $((Errors<125?Errors:125))


### PR DESCRIPTION
Add a test case for `<>;` with `-c` option

See https://www.illumos.org/issues/13512

Please review at https://code.illumos.org/c/illumos-gate/+/1226

See also https://github.com/att/ast/issues/9